### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,20 +12,20 @@ PrimitiveScheduler	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-addTask	             KEYWORD2
-getTime	             KEYWORD2
-getIntervalTime	     KEYWORD2
-getTaskExecutionTime KEYWORD2
-getTaskSkipped       KEYWORD2
-getTaskCount         KEYWORD2
-resetTask            KEYWORD2
-run                  KEYWORD2
+addTask	KEYWORD2
+getTime	KEYWORD2
+getIntervalTime	KEYWORD2
+getTaskExecutionTime	KEYWORD2
+getTaskSkipped	KEYWORD2
+getTaskCount	KEYWORD2
+resetTask	KEYWORD2
+run	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-ADD_SUCCESS LITERAL1
-ADD_FAIL    LITERAL1
-MAX_TASK    LITERAL1
+ADD_SUCCESS	LITERAL1
+ADD_FAIL	LITERAL1
+MAX_TASK	LITERAL1
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords